### PR TITLE
Fix ValueError due to inhomogeneous numpy (v1.24+) array

### DIFF
--- a/racecar/SDRaceCar.py
+++ b/racecar/SDRaceCar.py
@@ -114,7 +114,7 @@ class SDRaceCar():
             X_at_H = self.track[:, self.closest_track_ind + self.Horizon]
         return (np.array(
             [self.x, self.y, self.psi, self.v_x, self.v_y, self.omega,
-             X_at_H]))
+             X_at_H], dtype=object))
 
     def step(self, action):
         # Steps the simulation one time unit into the future


### PR DESCRIPTION
This line creates a numpy array of `float`s and a sequence (`X_at_H`) as one of its elements. This infers the array's `dtype=object`. This "feature" was unintended behavior. It was deprecated and raised a warning. As of Numpy v1.24, this feature was removed. Instantiating an `SDRaceCar` always throws
```ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (7,) + inhomogeneous part.```

More on this here:
https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
https://github.com/numpy/numpy/pull/22004

I explicitly set `dtype=object`. This change can be verified by instantiating an `SDRaceCar` object using Numpy v1.24 or newer with and without `dtype=object`.